### PR TITLE
First swing

### DIFF
--- a/src/main/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSource.java
+++ b/src/main/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSource.java
@@ -1,5 +1,6 @@
 package com.bambora.jenkins.plugin.casc.secrets.ssm;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
@@ -38,6 +39,9 @@ public class AwsSsmSecretSource extends SecretSource {
             return Optional.empty();
         } catch (AWSSimpleSystemsManagementException e) {
             LOG.log(Level.SEVERE, "Error getting ssm secret: " + resolveKey, e);
+            return Optional.empty();
+        } catch (SdkClientException e) {
+            LOG.log(Level.SEVERE, "Error building sdk: " + resolveKey, e);
             return Optional.empty();
         }
     }

--- a/src/test/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSourceTest.java
+++ b/src/test/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSourceTest.java
@@ -1,5 +1,6 @@
 package com.bambora.jenkins.plugin.casc.secrets.ssm;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.model.AWSSimpleSystemsManagementException;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
@@ -78,5 +79,14 @@ public class AwsSsmSecretSourceTest {
         Assert.assertEquals(Optional.of("value"), underTest.reveal("prefix.parameter"));
     }
 
+    @Test
+    public void errorMissingRegion() throws Exception{
+        AWSSimpleSystemsManagement client = Mockito.mock(AWSSimpleSystemsManagement.class);
+        PowerMockito.doReturn(client)
+                .when(underTest, "getClient");
 
+        Mockito.when(client.getParameter(Mockito.any())).thenThrow(SdkClientException.class);
+
+        Assert.assertEquals(Optional.empty(), underTest.reveal("parameter"));
+    }
 }


### PR DESCRIPTION
Motivation: In testing with this plugin I noticed that if a local AWS was missing my Jenkins service would fail to start. In my use case, I will rely on ECS Container Agent for these details, but locally they will always be unavailable. Catching and logging this exception seems reasonable to me, but there might be a better path forward. Stack trace below:

```
com.amazonaws.SdkClientException: Unable to find a region via the region provider chain. Must provide an explicit region in the builder or setup environment to supply a region.
	at com.amazonaws.client.builder.AwsClientBuilder.setRegion(AwsClientBuilder.java:462)
	at com.amazonaws.client.builder.AwsClientBuilder.configureMutableProperties(AwsClientBuilder.java:424)
	at com.amazonaws.client.builder.AwsSyncClientBuilder.build(AwsSyncClientBuilder.java:46)
	at com.bambora.jenkins.plugin.casc.secrets.ssm.AwsSsmSecretSource.getClient(AwsSsmSecretSource.java:48)
	at com.bambora.jenkins.plugin.casc.secrets.ssm.AwsSsmSecretSource.reveal(AwsSsmSecretSource.java:34)
	at io.jenkins.plugins.casc.SecretSourceResolver.lambda$null$aeeb512d$1(SecretSourceResolver.java:40)
	at io.vavr.CheckedFunction0.lambda$unchecked$52349c75$1(CheckedFunction0.java:201)
	at io.jenkins.plugins.casc.SecretSourceResolver.lambda$reveal$2(SecretSourceResolver.java:40)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1359)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:498)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:464)
	at io.jenkins.plugins.casc.SecretSourceResolver.reveal(SecretSourceResolver.java:42)
	at io.jenkins.plugins.casc.SecretSourceResolver.lambda$handle$1(SecretSourceResolver.java:32)
	at io.vavr.Tuple2.apply(Tuple2.java:239)
	at io.jenkins.plugins.casc.SecretSourceResolver.handle(SecretSourceResolver.java:31)
	at io.jenkins.plugins.casc.SecretSourceResolver.lambda$interpolator$0(SecretSourceResolver.java:24)
	at org.bigtesting.interpolatd.core.SubstitutionHandlerImpl.interpolate(SubstitutionHandlerImpl.java:52)
	at org.bigtesting.interpolatd.core.InterpolationHandlerImpl.interpolate(InterpolationHandlerImpl.java:69)
	at org.bigtesting.interpolatd.Interpolator.interpolate(Interpolator.java:59)
	at io.jenkins.plugins.casc.SecretSourceResolver.resolve(SecretSourceResolver.java:19)
	at io.jenkins.plugins.casc.impl.configurators.PrimitiveConfigurator.configure(PrimitiveConfigurator.java:46)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.tryConstructor(DataBoundConfigurator.java:130)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.instance(DataBoundConfigurator.java:73)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:264)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.configure(DataBoundConfigurator.java:79)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:96)
	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:43)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.tryConstructor(DataBoundConfigurator.java:122)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.instance(DataBoundConfigurator.java:73)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:264)
	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.check(DataBoundConfigurator.java:97)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:341)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:284)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:349)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:284)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$8(ConfigurationAsCode.java:657)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:620)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:657)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:642)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:545)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:275)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:267)
Caused: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1096)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused: org.jvnet.hudson.reactor.ReactorException
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:48)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1130)
	at jenkins.model.Jenkins.<init>(Jenkins.java:932)
	at hudson.model.Hudson.<init>(Hudson.java:85)
	at hudson.model.Hudson.<init>(Hudson.java:81)
	at hudson.WebAppMain$3.run(WebAppMain.java:233)
Caused: hudson.util.HudsonFailedToLoad
	at hudson.WebAppMain$3.run(WebAppMain.java:250)
```