### PR TITLE
update aws-sdk-java to 1.11.821

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.341</version>
+            <version>1.11.821</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
update aws-sdk-java to newest version to support IAM roles for kubernetes service accounts.

https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java#L49