### PR TITLE
Made CASC_SSM_PREFIX work properly with parameters stored in Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Plugin will also try to resolve secrets
         id: "cred-id"
         secret: /aws/reference/secretsmanager/${filename}
 
-from Secrets Manager with name _filename_ (or _prefix + filename_ provided _CAASC_SSM_PREFIX_ is defined). 
+from Secrets Manager with name _filename_ (or _prefix + filename_ provided _CASC_SSM_PREFIX_ is defined). 
 
 Code has been contributed by Bambora

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Plugin will try to resolve secrets
       - string:
         id: "cred-id"
         secret: ${filename}
-    
-from SSM with name _filename_. 
+
+from SSM with name _filename_.
 
 If a prefix is needed then configure environment variable _CASC_SSM_PREFIX_.
 Example:
@@ -39,5 +39,13 @@ CASC_SSM_PREFIX=jenkins.master.
 
 It will then resolve the example above with name _jenkins.master.filename_ from SSM.
 
-Code has been contributed by Bambora
+Plugin will also try to resolve secrets
 
+    - credentials:
+      - string:
+        id: "cred-id"
+        secret: /aws/reference/secretsmanager/${filename}
+
+from Secrets Manager with name _filename_ (or _prefix + filename_ provided _CAASC_SSM_PREFIX_ is defined). 
+
+Code has been contributed by Bambora

--- a/src/main/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSource.java
+++ b/src/main/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSource.java
@@ -19,16 +19,13 @@ import java.util.logging.Logger;
 public class AwsSsmSecretSource extends SecretSource {
 
     public static final String CASC_SSM_PREFIX = "CASC_SSM_PREFIX";
+    public static final String SECRETS_MANAGER_PREFIX = "/aws/reference/secretsmanager/";
 
     private static final Logger LOG = Logger.getLogger(AwsSsmSecretSource.class.getName());
 
     @Override
     public Optional<String> reveal(String key) {
-        String resolveKey = key;
-        String prefix =  getSystemProperty();
-        if (prefix != null) {
-            resolveKey = prefix + key;
-        }
+        String resolveKey = getResolveKey(key);
         try {
             GetParameterRequest request = new GetParameterRequest();
             request.withName(resolveKey).withWithDecryption(true);
@@ -56,4 +53,16 @@ public class AwsSsmSecretSource extends SecretSource {
         return System.getenv(CASC_SSM_PREFIX);
     }
 
+    // Visible for testing
+    public String getResolveKey(String key) {
+        String prefix =  getSystemProperty();
+        if (prefix != null) {
+            if (key.startsWith(SECRETS_MANAGER_PREFIX)) {
+                return SECRETS_MANAGER_PREFIX + prefix + key.substring(SECRETS_MANAGER_PREFIX.length());
+            } else {
+                return prefix + key;
+            }
+        }
+        return key;
+    }
 }

--- a/src/test/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSourceTest.java
+++ b/src/test/java/com/bambora/jenkins/plugin/casc/secrets/ssm/AwsSsmSecretSourceTest.java
@@ -89,4 +89,26 @@ public class AwsSsmSecretSourceTest {
 
         Assert.assertEquals(Optional.empty(), underTest.reveal("parameter"));
     }
+
+    @Test
+    public void resolveKey() throws Exception{
+        Assert.assertEquals(underTest.getResolveKey("parameter"), "parameter");
+    }
+
+    @Test
+    public void resolveKeyWithCascPrefix() throws Exception{
+        Assert.assertEquals(underTest.getResolveKey(AwsSsmSecretSource.SECRETS_MANAGER_PREFIX + "parameter"), AwsSsmSecretSource.SECRETS_MANAGER_PREFIX + "parameter");
+    }
+
+    @Test
+    public void resolveKeyWithSecretsManagerPrefix() throws Exception{
+        PowerMockito.doReturn("prefix.").when(underTest, "getSystemProperty");
+        Assert.assertEquals(underTest.getResolveKey("parameter"), "prefix.parameter");
+    }
+
+    @Test
+    public void resolveKeyWithCascAndSecretsManagerPrefixes() throws Exception{
+        PowerMockito.doReturn("prefix.").when(underTest, "getSystemProperty");
+        Assert.assertEquals(underTest.getResolveKey(AwsSsmSecretSource.SECRETS_MANAGER_PREFIX + "parameter"), AwsSsmSecretSource.SECRETS_MANAGER_PREFIX + "prefix.parameter");
+    }
 }


### PR DESCRIPTION
###### Description
According to [this guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html) it is possible to reference **Secrets Manager** from **Parameter Store**. To do so parameter key must be prefixed with `/aws/reference/secretsmanager/`. This PR ensures that `/aws/reference/secretsmanager/` prefixed is respected even if `CASC_SSM_PREFIX` variable is set.

###### Example
Given the following casc config entry
```
- credentials:
      - string:
        id: "cred-id"
        secret: /aws/reference/secretsmanager/my.parameter.name
```
and the following `CASC_SSM_PREFIX` value
```
export CASC_SSM_PREFIX='my.prefix'
```
the CASC SSM Plugin would try to retrieve a parameter with the following name
```
/aws/reference/secretsmanager/my.prefix.my.parameter.name
```

###### Testing
- [x] `mvn test`